### PR TITLE
fix: avoid segfault when VNC server offers only None auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,16 +139,14 @@ func recorder(c *cli.Context) error {
 		ServerMessageCh:  cchServer,
 		// serverCutText (defined above) overrides the buggy default handler.
 		Messages: append(append([]vnc.ServerMessage{}, vnc.DefaultServerMessages...), &serverCutText{}),
+		// Only Raw and CopyRect read a fixed byte count per rect, so they can't
+		// desync the stream. vnc2video's compressed decoders (Tight/ZRLE/Hextile)
+		// are an incomplete port and corrupt the stream on some content, crashing
+		// with a bogus "unsupported encoding". The server paints the cursor into
+		// normal updates when no cursor pseudo-encoding is advertised.
 		Encodings: []vnc.Encoding{
 			&vnc.RawEncoding{},
-			&vnc.TightEncoding{},
-			&vnc.HextileEncoding{},
-			&vnc.ZRLEEncoding{},
 			&vnc.CopyRectEncoding{},
-			&vnc.CursorPseudoEncoding{},
-			&vnc.CursorPosPseudoEncoding{},
-			&vnc.ZLibEncoding{},
-			&vnc.RREEncoding{},
 		},
 		ErrorCh: errorCh,
 	}
@@ -186,14 +184,8 @@ func recorder(c *cli.Context) error {
 	}
 
 	vncConnection.SetEncodings([]vnc.EncodingType{
-		vnc.EncCursorPseudo,
-		vnc.EncPointerPosPseudo,
 		vnc.EncCopyRect,
-		vnc.EncTight,
-		vnc.EncZRLE,
-		vnc.EncHextile,
-		vnc.EncZlib,
-		vnc.EncRRE,
+		vnc.EncRaw,
 	})
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	vnc "github.com/amitbet/vnc2video"
 	"github.com/sirupsen/logrus"
@@ -15,6 +16,30 @@ import (
 	"syscall"
 	"time"
 )
+
+// serverCutText replaces vnc2video's ServerCutText handler, which reads only
+// 1 byte of padding after the message type instead of the 3 the RFB protocol
+// requires. The 2-byte under-read desyncs the stream and corrupts every
+// subsequent framebuffer update. Embeds the original to inherit Type/Write/etc.
+type serverCutText struct {
+	vnc.ServerCutText
+}
+
+func (*serverCutText) Read(c vnc.Conn) (vnc.ServerMessage, error) {
+	var pad [3]byte
+	if err := binary.Read(c, binary.BigEndian, &pad); err != nil {
+		return nil, err
+	}
+	msg := vnc.ServerCutText{}
+	if err := binary.Read(c, binary.BigEndian, &msg.Length); err != nil {
+		return nil, err
+	}
+	msg.Text = make([]byte, msg.Length)
+	if err := binary.Read(c, binary.BigEndian, &msg.Text); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
 
 func main() {
 	app := &cli.App{
@@ -112,7 +137,8 @@ func recorder(c *cli.Context) error {
 		PixelFormat:      vnc.PixelFormat32bit,
 		ClientMessageCh:  cchClient,
 		ServerMessageCh:  cchServer,
-		Messages:         vnc.DefaultServerMessages,
+		// serverCutText (defined above) overrides the buggy default handler.
+		Messages: append(append([]vnc.ServerMessage{}, vnc.DefaultServerMessages...), &serverCutText{}),
 		Encodings: []vnc.Encoding{
 			&vnc.RawEncoding{},
 			&vnc.TightEncoding{},
@@ -200,7 +226,11 @@ func recorder(c *cli.Context) error {
 	for {
 		select {
 		case err := <-errorCh:
-			panic(err)
+			logrus.WithError(err).Error("VNC stream error, stopping recording.")
+			vcodec.Close()
+			// give some time to write the file
+			time.Sleep(time.Second * 1)
+			return err
 		case msg := <-cchClient:
 			logrus.WithFields(logrus.Fields{
 				"messageType": msg.Type(),

--- a/main.go
+++ b/main.go
@@ -49,8 +49,8 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "password",
-				Value:   "secret",
-				Usage:   "Password to connect to the VNC host",
+				Value:   "",
+				Usage:   "Password to connect to the VNC host (empty uses None auth)",
 				EnvVars: []string{"VR_VNC_PASSWORD"},
 			},
 			&cli.IntFlag{


### PR DESCRIPTION
Three bugs prevented recording against a VNC server offering only `None` auth.

- **Segfault on connect:** `--password` defaulted to `"secret"`, forcing VNC auth; when no handler matches the server's offer, upstream dereferences a nil security handler. Fix: default password to empty (`None` auth).
- **Crash from `ServerCutText`:** vnc2video reads 1 padding byte instead of the 3 RFB requires, so every clipboard update desyncs the stream by 2 bytes. Fix: supply a corrected `ServerCutText` via `ClientConfig.Messages`.
- **Crash from compressed decoders:** vnc2video's Tight/ZRLE/Hextile decoders are an incomplete port that miscounts bytes on some content, desyncing the stream (bogus `unsupported encoding`). Fix: advertise only `Raw` + `CopyRect`, which read a fixed byte count and can't desync. Also stop gracefully on stream errors instead of panicking.

Test plan: `./vnc-recorder --host localhost --port <none-auth-server>` records a valid h264 mp4 continuously (verified 60 s) instead of crashing within seconds.
